### PR TITLE
suggested two extra steps in setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ I recommend using `conda` from the Anaconda Distribution: https://www.anaconda.c
 Once installed, you can execute the following:
 1. `conda create -n nn-tutorial python=3.7`
 2. `conda activate nn-tutorial`
-3. `conda install pytorch torchvision jupyter pandas plotnine -c pytorch`
+3. `conda install pytorch torchvision jupyter pandas -c pytorch`
+4. `conda install plotnine -c conda-forge`
+5. `conda install nb_conda_kernels`
 
 ### Running the tutorial
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Once installed, you can execute the following:
 2. `conda activate nn-tutorial`
 3. `conda install pytorch torchvision jupyter pandas -c pytorch`
 4. `conda install plotnine -c conda-forge`
+
+Note: if you end up having trouble with the Jupyter notebook not being able to find the packages you've installed in your environment, it isn't using the right kernel, and the following may solve this problem (in any case it won't hurt):
+
 5. `conda install nb_conda_kernels`
 
 ### Running the tutorial


### PR DESCRIPTION
I did get it to work. This is what I had to do:
first thing: I need the package `nb_conda_kernels` in order to get jupyter notebook to run using a kernel with the packages I've installed in the virtual environment.
second thing: `plotnine` is not available from the channel `pytorch`, but it is in `conda-forge` I needed to make the change to get it to be found.